### PR TITLE
Fixed vertex shader compilation on desktop OpenGL

### DIFF
--- a/imgui_impl_cocos2dx.cpp
+++ b/imgui_impl_cocos2dx.cpp
@@ -440,6 +440,11 @@ void ImGui_ImplCocos2dx_DestroyFontsTexture()
 bool ImGui_ImplCocos2dx_CreateDeviceObjects()
 {
 	static auto vertex_shader = R"(
+#ifndef GL_ES
+#define lowp
+#define mediump
+#endif
+
 #if __VERSION__ >= 300
 
 layout(location=0) in vec2 a_position;


### PR DESCRIPTION
## Description
We found an issue after testing the latest changes of the repo which prevented the compilation of a shader on Windows.

Precision modifiers for OpenGL ES are not allowed on OpenGL 2.0
To fix this, empty definitions were used to remove the modifiers.